### PR TITLE
Fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Load DataMaps and the two libraries DataMaps depends on (d3 and topojson).
 
 Add a map configuration object to your scope to bind to the directive
 ```js
-$scope.map = {
+$scope.mapObject = {
   scope: 'usa',
   options: {
     width: 1110,
@@ -58,16 +58,16 @@ $scope.map = {
   },
   data: {
     "AZ": {
-      "fillkey": "MEDIUM",
+      "fillKey": "MEDIUM",
     },
     "CO": {
-      "fillkey": "HIGH",
+      "fillKey": "HIGH",
     },
     "DE": {
-      "fillkey": "LOW",
+      "fillKey": "LOW",
     },
     "GA": {
-      "fillkey": "MEDIUM",
+      "fillKey": "MEDIUM",
     }
   },
 }


### PR DESCRIPTION
Mismatched variables names (map/mapObject).
Wrong data key case (fillkey should be fillKey).